### PR TITLE
fix link conversion to handle anchors if present

### DIFF
--- a/src/markdownProcessor.ts
+++ b/src/markdownProcessor.ts
@@ -144,7 +144,8 @@ function checkForLinks(line: string): string {
 function processUrlParts(urlParts: string[], isBlog: boolean): string[] {
     urlParts = [...urlParts];  // create a copy to not modify original
 
-    const file = urlParts[urlParts.length - 1];
+    const [file, anchor] = urlParts[urlParts.length - 1].split("#");
+
     let parentFolder = urlParts[urlParts.length - 2];
 
     if (parentFolder.endsWith("+")) {
@@ -164,6 +165,10 @@ function processUrlParts(urlParts: string[], isBlog: boolean): string[] {
 
     if (!isBlog) {
         urlParts = urlParts.map(part => removeNumberPrefix(part));
+    }
+    
+    if (anchor) {
+      urlParts[urlParts.length - 1] = urlParts[urlParts.length - 1] + "#" + anchor.split("%20").join("-").toLowerCase();
     }
 
     return urlParts;


### PR DESCRIPTION
Markdown links can have an optional anchor at the end: a link to a specific section/heading.

If I am linking to heading `# My Heading 1` in `My Note`, then in Obsidian, the link looks like this:

```
[My Heading 1](path/.../My%20Note#My%20Heading%201)
```

However, this format is not supported in Docusaurus. Anchor links in Docusaurus cannot have spaces (`%20` is replaced with `-`) and the anchors must be lowercased.

Additionally, if there is an anchor, then the current behavior to remove the `.md` file extension will not work, since the `.md` is not the end of the url part, the anchor is, so this addresses that as well.

(PS: Love this plugin! Thanks for setting it up 👍 )