### PR TITLE
fix link searching to detect all links in a given line

### DIFF
--- a/src/markdownProcessor.ts
+++ b/src/markdownProcessor.ts
@@ -107,21 +107,21 @@ const convertAdmonition = (line: string, isInAdmonition: boolean, isInQuote: boo
 };
 
 function checkForLinks(line: string): string {
-    const pattern = /\[([^\]]+)\]\(([^)]+)\)/;
-    const match = line.match(pattern);
+    const pattern = /\[([^\]]+)\]\(([^)]+)\)/g;
+    const matches = [...line.matchAll(pattern)];
 
-    if (match) {
+    return matches.reduce((processedLine, match) => {
 
         const url = match[2];
 
         // keep external links as is
         if (url.includes("http")) {
-            return line;
+            return processedLine;
         // only continue with internal links
         } else {
             const urlParts = url.split("/");
 
-            if (urlParts.length <= 1) return line;
+            if (urlParts.length <= 1) return processedLine;
 
             let mainFolder = urlParts[0];
 
@@ -135,10 +135,9 @@ function checkForLinks(line: string): string {
             const processedUrlParts = processUrlParts(urlParts, isBlog);
 
             const newUrl = "/" + processedUrlParts.join("/");
-            return line.replace(url, newUrl);
+            return processedLine.replace(url, newUrl);
         }
-    }
-    return line
+    }, line);
 }
 
 function processUrlParts(urlParts: string[], isBlog: boolean): string[] {


### PR DESCRIPTION
In the previous behavior, only the first link of a line was being detected, because the regex did not have the global flag, and it wasn't doing a `matchAll` check. 

In updated behavior, it does a match all, and iterates through the matches (i.e., the links), reducing the line at each step by updating each link.